### PR TITLE
docs: add doc-maintenance loop (AGENTS, CHANGELOG, en README, verify gates)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## 变更说明
+
+<!-- 一句话说明本次变更的内容与动机 -->
+
+## 文档同步检查（必须勾选）
+
+- [ ] 行为 / 接口 / 依赖变化 → `README.md`（中文）已同步
+- [ ] `README.en.md`（英文）已同步（双语必须成对）
+- [ ] `CHANGELOG.md` 已更新，且版本号与 `package.json` 一致
+- [ ] 架构级决策变化 → `ARCHITECTURE.md` 已更新（旧决策保留并标注取代状态）
+- [ ] `pnpm verify:docs`、`pnpm typecheck`、`pnpm build` 通过

--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -1,0 +1,22 @@
+name: verify-docs
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify docs (version / bilingual pairing / links)
+        run: |
+          CHANGED=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.event.pull_request.base.ref }}"
+            CHANGED="$(git diff --name-only "$BASE"...HEAD || true)"
+          fi
+          node scripts/verify-docs.mjs --changed "$CHANGED"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+本仓库是 `@mombrane/dsh-ui-subagent-monitor`（DeepSeek Harness Web 扩展插件）的**发布副本**；DSH monorepo 内的 `packages/client/ui-subagent-monitor` 是开发源，两者需手工同步（见 ARCHITECTURE.md §4）。
+
+## 仓库布局
+
+- `src/` — 源码：`index.ts`（Node 半身）+ `client/`（Browser 半身）
+- `lib/` — 预构建产物（随仓库分发，**勿手改**，由 `pnpm build` 生成）
+- `README.md` / `README.en.md` — 对外契约（中文 / 英文，**必须成对同步**）
+- `ARCHITECTURE.md` — 设计决策与数据流（决策记录）
+- `CHANGELOG.md` — 变更史（与 `package.json` 版本号一致）
+- `cordis.patch.yml` — dsh.bundle 组合插入清单
+- `scripts/verify-docs.mjs` — 文档门禁脚本（版本 / 双语 / 链接）
+
+## 命令
+
+```sh
+pnpm build       # tsdown 构建 lib/
+pnpm typecheck   # tsc --noEmit
+pnpm verify:docs # 文档门禁（本地跑一遍再提交）
+```
+
+## 文档规则
+
+1. **非平凡变更必须在同一 PR 同步文档**：行为 / 接口 / 依赖变化 → 更新 README 特性表与 CHANGELOG；架构级决策 → 更新 ARCHITECTURE.md。只有纯机械 / 局部编辑可豁免。
+2. **双语配对**：`README.md`（中文）与 `README.en.md`（英文）必须同 PR 同步修改，内容保持等价；只改一边会被 CI 拒绝。
+3. **版本号三处一致**：`package.json` 的 `version`、CHANGELOG 最新条目、git tag（发布时）。README 不单独维护更新记录，只链接 CHANGELOG。
+4. **决策状态**：ARCHITECTURE.md 中的决策被取代时**保留原文**，在小节标题后标注 `（已被 §x.x 取代，YYYY-MM-DD）`，新决策写入对应小节；不删除、不改写旧决策。
+5. **发布流程**：`pnpm verify:docs` + `pnpm typecheck` + `pnpm build` 全过 → 把 CHANGELOG 的 `[Unreleased]` 条目并入新版本号 → 提交并打 tag → `gh release create` 关联 CHANGELOG 内容。
+
+## 门禁
+
+`.github/workflows/verify-docs.yml` 在 PR 与 master 推送时运行 `scripts/verify-docs.mjs`：
+CHANGELOG 版本与 `package.json` 一致、README 双语配对、相对链接有效性。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,9 @@
 
 > 本文回答三个问题：**它是什么、为什么这么做、它是怎么运转的**。
 > 面向对象：想要理解、修改或二次分发本插件的开发者。
+>
+> **决策状态约定**：本文的设计决策被后续变更取代时，保留原文，在小节标题后标注
+> `（已被 §x.x 取代，YYYY-MM-DD）`，并把新决策写入对应小节；本文件与行为/架构变更同 PR 更新。
 
 ---
 
@@ -152,8 +155,13 @@ dsh-subagent-monitor/
 ├── tsconfig.json
 ├── tsdown.config.ts        # 自包含构建：内联平台模块与模块加载器
 ├── lib/                    # 预构建产物（index.js / client.js）
-├── README.md
+├── README.md               # 对外契约（中文）
+├── README.en.md            # 对外契约（英文，与中文版配对同步）
+├── CHANGELOG.md            # 变更史（与 package.json 版本对齐）
+├── AGENTS.md               # 仓库常驻规则（agent / 协作者）
 ├── ARCHITECTURE.md         # 本文档
+├── scripts/verify-docs.mjs # 文档门禁（版本 / 双语 / 链接）
+├── .github/                # PR 模板 + verify-docs CI
 └── LICENSE                 # MIT
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+本文件记录 `@mombrane/dsh-ui-subagent-monitor` 所有值得记录的变更。
+格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，版本号遵循[语义化版本](https://semver.org/lang/zh-CN/)。
+
+## [Unreleased]
+
+### Added
+
+- `AGENTS.md`：仓库常驻规则（文档与代码同 PR 同步、双语配对、版本对齐、决策状态约定）。
+- `README.en.md`：英文 README，与中文版双语配对。
+- 文档门禁 `scripts/verify-docs.mjs` + GitHub Actions（版本 / CHANGELOG 一致、双语配对、相对链接检查）。
+- PR 模板（`.github/PULL_REQUEST_TEMPLATE.md`）：文档同步 checklist。
+
+## [0.1.0] - 2026-08-15
+
+### Added
+
+- 卡片化实时面板：运行中（🔵 蓝色呼吸 + 秒表）、完成、失败、已打断、令牌上限、已拒绝、已结束（历史回填，结局未观测）。
+- 侧栏底部「子代理」入口 + 右上角常驻面板；孙代子代理树形缩进。
+- 「打开对话」跳转子代理会话 + 「← 主会话」一键返回。
+- 刷新 / 服务重启后自动恢复（常驻组合 + 持久目录历史回填）。
+- 移动端策略（≤768px 视口默认不弹出，侧栏入口仍可打开）。
+- `dsh.bundle` 官方安装通道（`cordis.patch.yml`），支持 `dsh plugin add`。

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,126 @@
+<h1 align="center">🤖 dsh-subagent-monitor</h1>
+
+<p align="center">
+  DeepSeek Harness (DSH) Web extension plugin · live subagent run monitor panel
+  <br/>
+  <a href="https://github.com/Mombrane/dsh-subagent-monitor/blob/master/LICENSE"><img alt="license" src="https://img.shields.io/badge/license-MIT-green"></a>
+  <img alt="platform" src="https://img.shields.io/badge/platform-Web-8b5cf6">
+  <img alt="dsh" src="https://img.shields.io/badge/DSH-0.1.x-2563eb">
+</p>
+
+[中文](README.md) | **English**
+
+---
+
+## ✨ What is it
+
+Adds a **Subagents** entry at the bottom of the DSH Web sidebar and a card-style panel pinned to the **top-right** corner of the screen, showing the live run status of every subagent spawned from the current session.
+
+```
+┌─ Running subagents ────────────── [Collapse ▴] [✕] ┐
+│ ┌───────────────────────────────────────────────┐ │
+│ │ 🔵 Count TS files in ui dir        [Open chat] │ │
+│ │    one-shot · 1a2b3c4d    running · 00:42     │ │
+│ └───────────────────────────────────────────────┘ │
+│ ┌───────────────────────────────────────────────┐ │
+│ │ 🟢 Demo subagent: count file types[Open chat] │ │
+│ │    spawn · 2b3c4d5e       done · 03:12        │ │
+│ └───────────────────────────────────────────────┘ │
+│  running 1 · done 1 · failed 0     [Clear done]  │
+└───────────────────────────────────────────────────┘
+```
+
+<!-- Screenshot placeholder: actual panel screenshot -->
+
+## 🎯 Features
+
+| Feature | Description |
+| --- | --- |
+| 🟢 Live status | running (🔵 blue breathing dot + stopwatch), done, failed, interrupted, token limit, rejected |
+| 🃏 Card list | one rounded card per subagent; **Open chat** on the right, status and elapsed time on the second line |
+| 🌲 Tree indent | grandchild subagents are indented to the right |
+| 🔙 One-click back | inside a subagent session, the panel shows a **← Main session** button |
+| 🔄 Refresh-proof | persistent composition row: the panel auto-recovers after page refresh / service restart |
+| 📱 Mobile-friendly | hidden by default at ≤768px viewport; the sidebar entry still opens it manually |
+
+## 📦 Installation
+
+### Option A · Install from GitHub (works now)
+
+```bash
+dsh plugin --profile <your-profile> add github:Mombrane/dsh-subagent-monitor
+# On first install, if prompted to allow build scripts, confirm in the profile's pnpm-workspace.yaml
+```
+
+### Option B · npm (coming soon)
+
+```bash
+dsh plugin --profile <your-profile> add @mombrane/dsh-ui-subagent-monitor
+```
+
+> `@mombrane/dsh-ui-subagent-monitor` is not published to the npm registry yet; one-line install once published.
+
+Restart `dsh web` to take effect. This repository is both a **DSH client plugin** (`dsh.client`) and a **composition bundle** (`dsh.bundle` + `cordis.patch.yml`), shipped with a prebuilt `lib/`.
+
+### Option C · Inline into the DSH source tree (for secondary development)
+
+```bash
+# 1. Copy this repo's src/ to <dsh>/packages/client/ui-subagent-monitor/
+# 2. Add the dependency to <dsh>/packages/bundle/web-app/package.json
+"@mombrane/dsh-ui-subagent-monitor": "workspace:*"
+```
+
+```yaml
+# 3. <dsh>/packages/bundle/web-app/cordis.patch.yml (after the ui-subagent row)
+- id: ui-subagent-monitor
+  name: '@mombrane/dsh-ui-subagent-monitor'
+```
+
+```bash
+# 4. Build + restart
+pnpm install && pnpm --filter @mombrane/dsh-ui-subagent-monitor bundle
+# restart dsh web
+```
+
+> Also add this package path to `references` in <dsh>/tsconfig.client.json, and point this
+> package's `tsdown.config.ts` at the monorepo preset (`import { clientBundle } from '../tsdown.client.ts'`).
+
+## 🏷️ Status legend
+
+| Status | Meaning |
+| --- | --- |
+| 🔵 Running | in progress, blue breathing dot + live stopwatch |
+| 🟢 Done | the panel witnessed a successful finish; shows elapsed time |
+| ⚪ Ended | backfilled history row: created before a service restart, outcome not observed (success/failure unknown) |
+| 🔴 Failed | ended in error |
+| 🟠 Interrupted / token limit / rejected | aborted / hit the token cap / request rejected |
+
+## ❓ FAQ
+
+**Does the panel disappear on page refresh?** No. It is a persistent composition row; the panel auto-recovers on every page load.
+
+**What is the difference between “Done” and “Ended”?** 🟢 is an outcome the panel observed live; ⚪ is history from before a service restart, outcome not observed.
+
+**How much history does the panel keep?** At most 200 rows per root session; the oldest ended rows are evicted beyond that.
+
+**Is it safe?** The polling route `/api/subagent-monitor/snapshot` binds to the loopback address with no auth; recommended for local / intranet use only.
+
+## 🌐 Ecosystem
+
+| Channel | Status |
+| --- | --- |
+| GitHub topics | `dsh-plugin`, `deepseek-harness` (auto-synced by Oh-My-DSH every 4 hours) |
+| Oh-My-DSH catalog | PR [#8](https://github.com/like-study1/Oh-My-DSH/pull/8) pending maintainer merge |
+| awesome-dsh-plugin | PR [#675](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/675) pending maintainer merge |
+
+## 📋 Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full history. Current version **0.1.0** (aligned with `package.json`).
+
+## 📖 Architecture
+
+Design decisions (why persistent, why a custom polling route, event attribution model) and data-flow details: [ARCHITECTURE.md](./ARCHITECTURE.md).
+
+## 📄 License
+
+[MIT](./LICENSE) © Mombrane

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
   <img alt="dsh" src="https://img.shields.io/badge/DSH-0.1.x-2563eb">
 </p>
 
+**中文** | [English](README.en.md)
+
 ---
 
 ## ✨ 是什么
@@ -113,7 +115,9 @@ pnpm install && pnpm --filter @mombrane/dsh-ui-subagent-monitor bundle
 
 ## 📋 更新记录
 
-- **v1.0.0**：初版发布 —— 卡片化实时面板、树形缩进、会话跳转与一键返回、刷新自恢复、移动端策略、`dsh.bundle` 官方安装通道。
+变更历史见 [CHANGELOG.md](./CHANGELOG.md)。当前版本 **0.1.0**（与 `package.json` 对齐）。
+
+- **v0.1.0**：初版发布 —— 卡片化实时面板、树形缩进、会话跳转与一键返回、刷新自恢复、移动端策略、`dsh.bundle` 官方安装通道。
 
 ## 📖 架构文档
 

--- a/README.md
+++ b/README.md
@@ -113,11 +113,9 @@ pnpm install && pnpm --filter @mombrane/dsh-ui-subagent-monitor bundle
 | Oh-My-DSH 插件目录 | PR [#8](https://github.com/like-study1/Oh-My-DSH/pull/8) 待维护者合并 |
 | awesome-dsh-plugin | PR [#675](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/675) 待维护者合并 |
 
-## 📋 更新记录
+## 📋 变更日志
 
-变更历史见 [CHANGELOG.md](./CHANGELOG.md)。当前版本 **0.1.0**（与 `package.json` 对齐）。
-
-- **v0.1.0**：初版发布 —— 卡片化实时面板、树形缩进、会话跳转与一键返回、刷新自恢复、移动端策略、`dsh.bundle` 官方安装通道。
+完整变更历史见 [CHANGELOG.md](./CHANGELOG.md)。当前版本 **0.1.0**（与 `package.json` 对齐）。
 
 ## 📖 架构文档
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mombrane/dsh-subagent-monitor.git"
+  },
+  "homepage": "https://github.com/Mombrane/dsh-subagent-monitor#readme",
+  "bugs": {
+    "url": "https://github.com/Mombrane/dsh-subagent-monitor/issues"
+  },
   "exports": {
     ".": {
       "types": "./lib/types/index.d.ts",
@@ -32,7 +40,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "verify:docs": "node scripts/verify-docs.mjs"
   },
   "files": [
     "lib/index.js",
@@ -41,6 +50,7 @@
     "cordis.patch.yml",
     "src",
     "README.md",
+    "README.en.md",
     "LICENSE"
   ],
   "dependencies": {

--- a/scripts/verify-docs.mjs
+++ b/scripts/verify-docs.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Lightweight documentation gate for dsh-subagent-monitor.
+ * Pure Node, zero dependencies. Checks:
+ *   1. CHANGELOG top version === package.json version
+ *   2. README.md / README.en.md bilingual pairing (when --changed is passed)
+ *   3. Relative markdown links resolve to existing files
+ *
+ * Usage:
+ *   node scripts/verify-docs.mjs
+ *   node scripts/verify-docs.mjs --changed "README.md ARCHITECTURE.md"
+ */
+import { readFileSync, existsSync } from 'node:fs'
+import { dirname, resolve, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const errors = []
+const fail = (msg) => errors.push(msg)
+
+// --- 1. CHANGELOG / package.json version consistency -------------------------
+let pkg
+try {
+  pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+} catch {
+  console.error('verify-docs: package.json is unreadable or invalid JSON')
+  process.exit(1)
+}
+const changelogPath = join(ROOT, 'CHANGELOG.md')
+if (!existsSync(changelogPath)) {
+  fail('CHANGELOG.md is missing')
+} else {
+  const changelog = readFileSync(changelogPath, 'utf8')
+  const topVersion = /^## \[(\d+\.\d+\.\d+)\]/m.exec(changelog)
+  if (!topVersion) fail('CHANGELOG.md: no `## [x.y.z]` version heading found')
+  else if (topVersion[1] !== pkg.version) {
+    fail(`version mismatch: CHANGELOG top is [${topVersion[1]}], package.json is ${pkg.version}`)
+  }
+}
+
+// --- 2. bilingual pairing (PR context only) ----------------------------------
+const args = process.argv.slice(2)
+const changedIdx = args.indexOf('--changed')
+if (changedIdx !== -1 && args[changedIdx + 1] && args[changedIdx + 1].trim()) {
+  const changed = new Set(args[changedIdx + 1].trim().split(/\s+/))
+  const pairs = [['README.md', 'README.en.md']]
+  for (const [a, b] of pairs) {
+    if (changed.has(a) !== changed.has(b)) {
+      fail(`bilingual pairing: ${a} and ${b} must change in the same PR`)
+    }
+  }
+}
+
+// --- 3. relative markdown link check -----------------------------------------
+const SCANNED = ['README.md', 'README.en.md', 'ARCHITECTURE.md', 'CHANGELOG.md', 'AGENTS.md']
+const LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g
+for (const file of SCANNED) {
+  const filePath = join(ROOT, file)
+  if (!existsSync(filePath)) {
+    fail(`missing doc file: ${file}`)
+    continue
+  }
+  const text = readFileSync(filePath, 'utf8')
+  let inFence = false
+  for (const line of text.split('\n')) {
+    if (line.trimStart().startsWith('```')) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    for (const m of line.matchAll(LINK_RE)) {
+      const target = m[2].trim()
+      if (!target || /^(https?:|mailto:)/.test(target) || target.startsWith('#')) continue
+      const withoutAnchor = target.split('#')[0]
+      if (!withoutAnchor) continue
+      const resolved = resolve(dirname(filePath), withoutAnchor)
+      if (!existsSync(resolved)) fail(`${file}: broken link -> ${target}`)
+    }
+  }
+}
+
+// --- report -------------------------------------------------------------------
+if (errors.length === 0) {
+  console.log('verify-docs: OK (version / bilingual pairing / links)')
+  process.exit(0)
+}
+console.error('verify-docs: violations found:')
+for (const e of errors) console.error('  - ' + e)
+process.exit(1)


### PR DESCRIPTION
## 变更说明

建立一套轻量的文档维护机制（借鉴 deepseek-harness 的 Agent Notes 思路，但按个人插件仓库的规模裁剪）：

- **AGENTS.md**：仓库常驻规则——非平凡变更必须同 PR 同步文档；README 双语配对；版本号三处一致；ARCHITECTURE 决策状态约定。
- **CHANGELOG.md**：keep-a-changelog 变更史，版本与 package.json 对齐（**0.1.0**，原 README 写的 v1.0.0 已修正）。
- **README.en.md**：英文版 README（对齐路线图 5.1 的 i18n 待办），与中文版成对。
- **README.md**：加语言切换；更新记录改为链接 CHANGELOG。
- **ARCHITECTURE.md**：加决策状态约定 + 更新目录树。
- **.github/PULL_REQUEST_TEMPLATE.md**：PR 文档同步 checklist。
- **.github/workflows/verify-docs.yml + scripts/verify-docs.mjs**：PR/推送时校验（版本一致、双语成对、相对链接有效），零依赖纯 Node。
- **package.json**：补 repository/homepage/bugs 元数据，files 加 README.en.md，加 verify:docs 脚本。

## 文档同步检查

- [x] README.md 已同步
- [x] README.en.md 已同步（双语成对）
- [x] CHANGELOG.md 已更新，版本与 package.json 一致（0.1.0）
- [x] ARCHITECTURE.md 已更新
- [x] verify-docs / typecheck / build 通过（build 用本机 tsdown 验证，typecheck 用 harness tsc 验证；本机 pnpm 因内网 registry 缺 @deepseek-ai 版本无法跑 install，与本次改动无关）
